### PR TITLE
fix(flux-system): set notifications targetNamespace

### DIFF
--- a/kubernetes/apps/flux-system/notifications/ks.yaml
+++ b/kubernetes/apps/flux-system/notifications/ks.yaml
@@ -9,6 +9,7 @@ spec:
   interval: 10m
   path: ./kubernetes/apps/flux-system/notifications/app
   prune: true
+  targetNamespace: flux-system
   wait: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
- Set `spec.targetNamespace: flux-system` on the Flux `Kustomization` for notifications.

## Why
Notification resources in `kubernetes/apps/flux-system/notifications/app/` intentionally omit `metadata.namespace`.
Without `targetNamespace`, reconciliation fails with:
- `Provider/slack namespace not specified ... (patch providers.notification.toolkit.fluxcd.io slack)`

## Test plan
- After merge, verify `flux get kustomization notifications -n flux-system` is Ready.